### PR TITLE
🐛 fix(workflow): update action reference in CI workflow

### DIFF
--- a/.github/workflows/ci-pr-merged-to-l10n.yml
+++ b/.github/workflows/ci-pr-merged-to-l10n.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Get VERSION from the Pull Request Title
         id: gvprt
-        uses: ltdorgtest/ci-common/.github/actions/get-version-from-pull-request-title@main
+        uses: localizethedocs/ci-common/.github/actions/get-version-from-pull-request-title@main
         with:
           pull-request-title: ${{ github.event.pull_request.title }}
 


### PR DESCRIPTION
Updated the action reference of get-version-from-pull-request-title from 'ltdorgtest/ci-common' to 'localizethedocs/ci-common'.